### PR TITLE
Issue #1 - JunitMergerBase rtrim() expects parameter 1 to be string

### DIFF
--- a/src/JunitMergerBase.php
+++ b/src/JunitMergerBase.php
@@ -69,11 +69,7 @@ abstract class JunitMergerBase implements JunitMergerInterface
     public function addXmlFiles(\Iterator $xmlFiles)
     {
         while ($xmlFiles->valid()) {
-            $xmlFile = rtrim($xmlFiles->current(), "\r\n");
-            if ($xmlFile !== '') {
-                $this->addXmlFile($xmlFile);
-            }
-
+            $this->addXmlFile($xmlFiles->current());
             $xmlFiles->next();
         }
 
@@ -85,12 +81,17 @@ abstract class JunitMergerBase implements JunitMergerInterface
      */
     public function addXmlFile($xmlFile)
     {
-        $filename = $xmlFile instanceof \SplFileInfo ? $xmlFile->getPathname() : $xmlFile;
+        $filename = $xmlFile instanceof \SplFileInfo ? $xmlFile->getPathname() : rtrim($xmlFile, "\r\n");
         $filename = preg_replace(
             '@^/proc/self/fd/(?P<id>\d+)$@',
             'php://fd/$1',
             $filename,
         );
+
+        if ($filename === '') {
+            return $this;
+        }
+
         $this->addXmlString(file_get_contents($filename));
 
         return $this;

--- a/tests/unit/JunitMergerTestBase.php
+++ b/tests/unit/JunitMergerTestBase.php
@@ -19,7 +19,7 @@ abstract class JunitMergerTestBase extends Unit
             'basic' => [
                 file_get_contents("$fixturesDir/junit-expected/a-b.xml"),
                 new \ArrayIterator([
-                    "$fixturesDir/junit/a.xml",
+                    new \SplFileObject("$fixturesDir/junit/a.xml"),
                     "$fixturesDir/junit/empty-long-new-line.xml",
                     "$fixturesDir/junit/empty-long-same-line.xml",
                     "$fixturesDir/junit/empty-short-space.xml",
@@ -35,8 +35,9 @@ abstract class JunitMergerTestBase extends Unit
         $cases = $this->casesMergeXmlFiles();
         foreach ($cases as &$case) {
             $strings = [];
+            /** @var string|\SplFileInfo $filename */
             foreach ($case[1] as $filename) {
-                $strings[] = file_get_contents($filename);
+                $strings[] = file_get_contents(is_string($filename) ? $filename : $filename->getPathname());
             }
             $case[1] = new \ArrayIterator($strings);
         }
@@ -47,7 +48,7 @@ abstract class JunitMergerTestBase extends Unit
     /**
      * @dataProvider casesMergeXmlFiles
      */
-    public function testMergeXmlFiles(string $expected, iterable $xmlFiles)
+    public function testMergeXmlFiles(string $expected, \Iterator $xmlFiles)
     {
         $merger = $this->createInstance();
 
@@ -70,7 +71,7 @@ abstract class JunitMergerTestBase extends Unit
     /**
      * @dataProvider casesMergeXmlStrings
      */
-    public function testMergeXmlStrings(string $expected, iterable $xmlStrings)
+    public function testMergeXmlStrings(string $expected, \Iterator $xmlStrings)
     {
         $merger = $this->createInstance();
 


### PR DESCRIPTION
Issue #1 - JunitMergerBase rtrim() expects parameter 1 to be string